### PR TITLE
Update leaderboard logic to match current server behavior.

### DIFF
--- a/agario-client.js
+++ b/agario-client.js
@@ -378,11 +378,12 @@ Client.prototype = {
 
         //leaderboard update in FFA mode
         '49': function(client, packet) {
-            var users = [];
+            var highlights = [];
+            var names = [];
             var count = packet.readUInt32LE();
 
             for(var i=0;i<count;i++) {
-                var id = packet.readUInt32LE();
+                var highlight = packet.readUInt32LE();
 
                 var name = '';
                 while(1) {
@@ -391,20 +392,23 @@ Client.prototype = {
                     name += String.fromCharCode(char);
                 }
 
-                users.push(id);
-                var ball = client.balls[id] || new Ball(client, id);
-                if(name) ball.setName(name);
-                ball.update();
+                highlights.push(highlight);
+                names.push(name);
             }
 
-            if(JSON.stringify(client.leaders) == JSON.stringify(users)) return;
-            var old_leaders = client.leaders;
-            client.leaders  = users;
+            if(JSON.stringify(client.leaderHighlights) == JSON.stringify(highlights) &&
+                JSON.stringify(client.leaderNames) == JSON.stringify(names)) {
+                return;
+            }
+            var old_highlights = client.leaderHighlights;
+            client.leaderHighlights = highlights;
+            var old_leaderNames = client.leaderNames;
+            client.leaderNames = names;
 
             if(client.debug >= 3)
-                client.log('leaders update: ' + JSON.stringify(users));
+                client.log('leaders update: ' + JSON.stringify(highlights) + ',' + JSON.stringify(names));
 
-            client.emitEvent('leaderBoardUpdate', old_leaders, users);
+            client.emitEvent('leaderBoardUpdate', old_highlights, highlights, old_leaderNames, names);
         },
 
         //teams scored update in teams mode

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -43,7 +43,7 @@ client.on('friendAdded', function(friend_id) { //on friendEaten event
 });
 //end of adding custom properties/events example
 
-client.once('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) { //when we receive leaders list. Fire only once
+client.on('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) { //when we receive leaders list.
     client.log('leaders on server: ' + names.join(', '));
 });
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -43,12 +43,8 @@ client.on('friendAdded', function(friend_id) { //on friendEaten event
 });
 //end of adding custom properties/events example
 
-client.once('leaderBoardUpdate', function(old, leaders) { //when we receive leaders list. Fire only once
-    var name_array = leaders.map(function(ball_id) { //converting leader's IDs to leader's names
-        return client.balls[ball_id].name || 'unnamed'
-    });
-
-    client.log('leaders on server: ' + name_array.join(', '));
+client.once('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) { //when we receive leaders list. Fire only once
+    client.log('leaders on server: ' + names.join(', '));
 });
 
 client.on('mineBallDestroy', function(ball_id, reason) { //when my ball destroyed

--- a/examples/multiple.js
+++ b/examples/multiple.js
@@ -51,12 +51,8 @@ ExampleBot.prototype = {
             bot.log('My new ball ' + ball_id);
         });
 
-        bot.client.once('leaderBoardUpdate', function(old, leaders) {
-            var name_array = leaders.map(function(ball_id) {
-                return bot.client.balls[ball_id].name || 'unnamed'
-            });
-
-            bot.log('Leaders on server: ' + name_array.join(', '));
+        bot.client.once('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) {
+            bot.log('Leaders on server: ' + names.join(', '));
         });
 
         bot.client.on('somebodyAteSomething', function(eater_ball, eaten_ball) {

--- a/examples/multiple.js
+++ b/examples/multiple.js
@@ -51,7 +51,7 @@ ExampleBot.prototype = {
             bot.log('My new ball ' + ball_id);
         });
 
-        bot.client.once('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) {
+        bot.client.on('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) {
             bot.log('Leaders on server: ' + names.join(', '));
         });
 

--- a/examples/socks.js
+++ b/examples/socks.js
@@ -76,7 +76,7 @@ AgarioClient.servers.getFFAServer(get_server_opt, function(srv) {
     //Create new agent for client
     client.agent = createAgent();
 
-    client.once('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) {
+    client.on('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) {
         client.log('Leaders on server: ' + names.join(', '));
         console.log('[SUCCESS!] Example succesfully connected to server through SOCKS server and received data. Example is over.');
         client.disconnect();

--- a/examples/socks.js
+++ b/examples/socks.js
@@ -76,12 +76,8 @@ AgarioClient.servers.getFFAServer(get_server_opt, function(srv) {
     //Create new agent for client
     client.agent = createAgent();
 
-    client.once('leaderBoardUpdate', function(old, leaders) {
-        var name_array = leaders.map(function(ball_id) {
-            return client.balls[ball_id].name || 'unnamed'
-        });
-
-        client.log('Leaders on server: ' + name_array.join(', '));
+    client.once('leaderBoardUpdate', function(old_highlights, highlights, old_names, names) {
+        client.log('Leaders on server: ' + names.join(', '));
         console.log('[SUCCESS!] Example succesfully connected to server through SOCKS server and received data. Example is over.');
         client.disconnect();
     });


### PR DESCRIPTION
From what I have seen, the leaderboard update message has apparently changed since the time this code was written.

The server doesn't send blob ids any more. Instead it sends a "boolean" 0 or 1 indicating whether you are on the leaderboard or not. The standard agar.io client uses this to decide whether your entry should be highlighted.

Because the callback function no longer gets ball ids (and thus can't derive name from ball id), I've added two more arguments to the callback function. Changing the signature is OK (in my opinion) because all such callbacks stopped working properly anyway, as of the time of the server change.

**TESTING:**

Prior to this change, the program ```examples/basic.js``` printed nonsensical leaderboard information like this:

worker: leaders on server: Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя, Ward♣Ðangзя

After this change, it prints leaderboard information like this:

worker: leaders on server: SAS, CELLulitis, MASTER, , , ee, , JUMBO, marcel B, ArcadePro