### PR TITLE
Move invocation of 'update' callback.

### DIFF
--- a/agario-client.js
+++ b/agario-client.js
@@ -314,13 +314,13 @@ Client.prototype = {
                 ball_id = packet.readUInt32LE();
 
                 ball = client.balls[ball_id] || new Ball(client, ball_id);
-                ball.update_tick = client.tick_counter;
-                ball.update();
                 if(ball.mine) {
                     ball.destroy({reason: 'merge'});
                     client.emitEvent('merge', ball.id);
                 }else{
                     ball.disappear();
+                    ball.update_tick = client.tick_counter;
+                    ball.update();
                 }
             }
         },


### PR DESCRIPTION
Rationale for this change:

Before this change, the "update" callback is in a useless place, because
it calls "update" before anything has changed on the Ball.

The question is where to move it to. It doesn't belong in the "then"
branch of the if, because it's not our practice to send update events
after destroy events (see for example lines 200 and 341). So it only
makes sense in the "else" branch.